### PR TITLE
feat: Generate shell completions on install

### DIFF
--- a/Formula/graphite.rb
+++ b/Formula/graphite.rb
@@ -6,17 +6,23 @@ class Graphite < Formula
   if OS.mac?
     url "https://github.com/withgraphite/homebrew-tap/releases/download/v0.21.0/gt-macos"
     sha256 "b498330dbfea3810ec0822d4d106f69fe8182c9a0eefbb8b9b794500c22cc573"
-    def install
-      bin.install "gt-macos" => "gt"
-    end
   end
 
   if OS.linux?
     url "https://github.com/withgraphite/homebrew-tap/releases/download/v0.21.0/gt-linux"
     sha256 "ea22d355da93c59300ee83ac9ef58d63126c41a80d9a39076a5de9420ae789d9"
-    def install
+  end
+
+  def install
+    if OS.mac?
+      bin.install "gt-macos" => "gt"
+    elsif OS.linux?
       bin.install "gt-linux" => "gt"
     end
+
+    chmod 0555, bin/"gt"
+    generate_completions_from_executable(bin/"gt", "completion", shells:                 [:bash, :zsh, :fish],
+                                                                 shell_parameter_format: :none)
   end
 
   # TODO

--- a/formula-templates/graphite.rb
+++ b/formula-templates/graphite.rb
@@ -6,17 +6,23 @@ class Graphite < Formula
   if OS.mac?
     url "{{urlMac}}"
     sha256 "{{shasumMac}}"
-    def install
-      bin.install "gt-macos" => "gt"
-    end
   end
 
   if OS.linux?
     url "{{urlLinux}}"
     sha256 "{{shasumLinux}}"
-    def install
+  end
+
+  def install
+    if OS.mac?
+      bin.install "gt-macos" => "gt"
+    elsif OS.linux?
       bin.install "gt-linux" => "gt"
     end
+
+    chmod 0555, bin/"gt"
+    generate_completions_from_executable(bin/"gt", "completion", shells:                 [:bash, :zsh, :fish],
+                                                                 shell_parameter_format: :none)
   end
 
   # TODO


### PR DESCRIPTION
Homebrew can automatically generate and install completions for bash,
zsh, and fish. For now, completion is limited to bash and zsh until
graphite adds fish support.

This simplifies the installation steps for homebrew users.