### PR TITLE
fix: Fix brew audit and style checks

### DIFF
--- a/Formula/graphite.rb
+++ b/Formula/graphite.rb
@@ -7,17 +7,23 @@ class Graphite < Formula
   if OS.mac?
     url "https://github.com/withgraphite/graphite-cli/releases/download/v0.20.34/gt-macos"
     sha256 "acf6a53b873703fcaa190293aae33a12a5db17e0bb21c3c3713e37d771c86de1"
-    def install
-      bin.install "gt-macos" => "gt"
-    end  
   end
 
   if OS.linux?
     url "https://github.com/withgraphite/graphite-cli/releases/download/v0.20.34/gt-linux"
     sha256 "61c19e9ceb2fe884b1f4f6eebaf96746ef048958c4f382a3c4dc82d6f1a95851"
-    def install
+  end
+
+  def install
+    if OS.mac?
+      bin.install "gt-macos" => "gt"
+    elsif OS.linux?
       bin.install "gt-linux" => "gt"
-    end  
+    end
+
+    chmod 0555, bin/"gt"
+    generate_completions_from_executable(bin/"gt", "completion", shells:                 [:bash, :zsh, :fish],
+                                                                 shell_parameter_format: :none)
   end
 
   # TODO

--- a/Formula/graphite.rb
+++ b/Formula/graphite.rb
@@ -1,8 +1,7 @@
 class Graphite < Formula
-  desc "The Graphite CLI allows you to easily manage your stacked-diff workflow."
+  desc "CLI that allows you to easily manage your stacked-diff workflow"
   homepage "https://graphite.dev/"
-  version "0.20.34"
-  license "None"
+  license "AGPL-3.0"
 
   if OS.mac?
     url "https://github.com/withgraphite/graphite-cli/releases/download/v0.20.34/gt-macos"
@@ -30,7 +29,6 @@ class Graphite < Formula
   # Hardware::CPU.intel?
   # Hardware::CPU.arm?
   # Hardware::CPU.is_64_bit?
-
 
   test do
     raise "Test not implemented."

--- a/formula-templates/graphite.rb
+++ b/formula-templates/graphite.rb
@@ -7,17 +7,23 @@ class Graphite < Formula
   if OS.mac?
     url "{{urlMac}}"
     sha256 "{{shasumMac}}"
-    def install
-      bin.install "gt-macos" => "gt"
-    end  
   end
 
   if OS.linux?
     url "{{urlLinux}}"
     sha256 "{{shasumLinux}}"
-    def install
+  end
+
+  def install
+    if OS.mac?
+      bin.install "gt-macos" => "gt"
+    elsif OS.linux?
       bin.install "gt-linux" => "gt"
-    end  
+    end
+
+    chmod 0555, bin/"gt"
+    generate_completions_from_executable(bin/"gt", "completion", shells:                 [:bash, :zsh, :fish],
+                                                                 shell_parameter_format: :none)
   end
 
   # TODO

--- a/formula-templates/graphite.rb
+++ b/formula-templates/graphite.rb
@@ -1,8 +1,7 @@
 class Graphite < Formula
-  desc "The Graphite CLI allows you to easily manage your stacked-diff workflow."
+  desc "CLI that allows you to easily manage your stacked-diff workflow"
   homepage "https://graphite.dev/"
-  version "{{version}}"
-  license "None"
+  license "AGPL-3.0"
 
   if OS.mac?
     url "{{urlMac}}"
@@ -30,7 +29,6 @@ class Graphite < Formula
   # Hardware::CPU.intel?
   # Hardware::CPU.arm?
   # Hardware::CPU.is_64_bit?
-
 
   test do
     raise "Test not implemented."

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,6 @@ yargs
           urlLinux,
           shasumMac,
           shasumLinux,
-          version: tag.slice(1).split("-")[0], // v1.2.3-abc => 1.2.3
         })
       );
     }


### PR DESCRIPTION
Fix errors and warnings from `brew style` and `brew audit`.

* Remove redundant version (it is scanned from the URL)
* Set license to match the CLI
* Descriptions should not start with an article or the formula name